### PR TITLE
Change run!{} macro to accept patterns instead of identifiers.

### DIFF
--- a/prelude/src/lib.rs
+++ b/prelude/src/lib.rs
@@ -153,14 +153,14 @@ macro_rules! run {
     //To still get good error messages, a nested macro is used, that matches against pat.
     ($binding:tt <= <$coerce:ident> $comp:expr; $($tail:tt)*) => {
         {
-            macro_rules! verify_pat { ($_:pat) => {}; } verify_pat!($binding);
+            macro_rules! verify_pat { ($_:pat_param) => {}; } verify_pat!($binding);
             $crate::Bind::bind::<$coerce, _>($comp, move |$binding| run!($($tail)*))
         }
     };
 
     ($binding:tt <= $comp:expr; $($tail:tt)*) => {
         {
-            macro_rules! verify_pat { ($_:pat) => {}; } verify_pat!($binding);
+            macro_rules! verify_pat { ($_:pat_param) => {}; } verify_pat!($binding);
             $crate::Bind::bind($comp, move |$binding| run!($($tail)*))
         }
     };


### PR DESCRIPTION
Lambdas support pattern matching for their parameters. This change enables the run!{} macro to accept patterns instead of identifiers.

The code is a bit convoluted, because of Follow-set Ambiguity Restrictions. It is not possible to match a `pat` fragment in front of "<=". Therefore the macro now matches against a `tt` and then tries to pass the result to a nested macro, which only accepts `pat`. This allows for relatively readable error messages.