### PR TITLE
Add explicit clone support to do-notation

### DIFF
--- a/prelude/src/lib.rs
+++ b/prelude/src/lib.rs
@@ -257,7 +257,6 @@ macro_rules! run {
     };
 }
 
-
 /// Construct a function that ignores its argument and returns the same value
 /// every time you call it.
 ///
@@ -362,9 +361,10 @@ mod test {
         );
 
         // Explicit clone in do-notation
-        #[derive(Clone,PartialEq, Debug)] struct NoCopy<A>(A);
+        #[derive(Clone, PartialEq, Debug)]
+        struct NoCopy<A>(A);
         assert_eq!(
-            run!{
+            run! {
                 t <= run! {
                     t <= Some(NoCopy(5u32)); //tests the syntax of assign without explicit clone.
                     Some(3i32); //here ownership of t is still clear, no clone needed. Tests syntax of non-assigning without clone.
@@ -385,6 +385,5 @@ mod test {
             },
             Some(NoCopy(6u32))
         );
-
     }
 }


### PR DESCRIPTION
This is the implementation of explicit clones in do-notation, as discussed in issue #6. The issue should be resolved by this.

To reduce the amount of code duplication, the match arms in the macro that do not contain explicit clone parameters forward to those that contain them.

I really hope the macro doesn't have any ambiguity now. I think it should be fine, but my experience with macros in Rust is still limited, so it is possible that I'm overlooking something.